### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "main": "out/main/index.js",
   "scripts": {
-    "dev": "ELECTRON_RUN_AS_NODE= electron-vite dev",
+    "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "start": "ELECTRON_RUN_AS_NODE= electron .",
+    "start": "electron .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=verbose",
     "test:watch": "vitest --reporter=verbose",


### PR DESCRIPTION
## Problem

On Windows PowerShell, the script crashed immediately with:
`'ELECTRON_RUN_AS_NODE' is not recognized as an internal or external command`

PowerShell doesn't understand the Unix `VAR= cmd` syntax used to set inline env vars.

## Fix

Remove the `ELECTRON_RUN_AS_NODE=` prefix entirely. `electron-vite` already manages this variable internally for its own build pipeline, so the wrapper is redundant.